### PR TITLE
AGENTS-102 Agents workers respond to TERM signal by deregistering from g...

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ type JobFunc func(Job) ([]byte, error)
 
 JobFunc is a function that takes in a Gearman job and does some work on it.
 
+#### type SigtermHandler
+
+```go
+type SigtermHandler func(*Worker)
+```
+
+SigtermHandler is the definition for the function called after the worker
+receives a TERM signal.
+
 #### type Worker
 
 ```go


### PR DESCRIPTION
...earman, completing work

This change updates the go baseworker to handle SIGTERM. It does this by listening for the
signal and running the specified sigtermHandler function for the worker. By default the worker
just calls Shutdown() and then exits, but implementers can overwrite this functionality if they
want custom behavior (for example the tests use this)
