### PR TITLE
Add go argsparser package

### DIFF
--- a/argsparser/argsparser.go
+++ b/argsparser/argsparser.go
@@ -1,0 +1,48 @@
+package argsparser
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ParseArgs converts the command line specified into a slice of the command line arguments.
+func ParseArgs(commandline string) ([]string, error) {
+	file, err := ioutil.TempFile("/tmp", "parseArgs")
+	defer os.Remove(file.Name())
+	if err != nil {
+		return nil, err
+	}
+	// This is a bit hacky, but we couldn't think of a better way to do it.
+	// We create a bash script and in that file we run a bash command that parses the
+	// command line arguments we wrote to the file. The bash script outputs each of the
+	// parsed arguments to stdout, separated by \n. We parse the stdout and return
+	// that to the caller.
+	file.WriteString("#!/bin/bash\n")
+	file.WriteString("bash -c 'while test ${#} -gt 0; do echo $1; shift; done;' _ " + commandline + "\n")
+
+	if err := file.Chmod(0744); err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(file.Name())
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	response, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		return nil, err
+	}
+	if err = cmd.Wait(); err != nil {
+		return nil, err
+	}
+	argsArray := strings.Split(string(response), "\n")
+	// Remove the last element of the argsArray because the output ends with an endline
+	// and has an empty last element
+	argsArray = argsArray[0 : len(argsArray)-1]
+	return argsArray, nil
+}

--- a/argsparser/argsparser_test.go
+++ b/argsparser/argsparser_test.go
@@ -1,0 +1,27 @@
+package argsparser
+
+import (
+	"strconv"
+	"testing"
+)
+
+// Helper function to assert that two strings are equal
+func checkStringsEqual(t *testing.T, expected string, actual string) {
+	if expected != actual {
+		t.Fatal("Actual response: " + actual + " does not match expected: " + expected)
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	argsArray, err := ParseArgs("\"arg with quotes\" secondArg thirdArg \"another with quotes\"")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(argsArray) != 4 {
+		t.Fatal("Args length = " + strconv.Itoa(len(argsArray)) + ", 4 expected")
+	}
+	checkStringsEqual(t, "arg with quotes", argsArray[0])
+	checkStringsEqual(t, "secondArg", argsArray[1])
+	checkStringsEqual(t, "thirdArg", argsArray[2])
+	checkStringsEqual(t, "another with quotes", argsArray[3])
+}


### PR DESCRIPTION
This package converts a command line string into a slice of its
arguments. It is necessary for the task wrapper we're writing which
converts gearman payloads to command line arguments for a process.

It's a bit hacky, but it's the best solution we could come up with.

I'm not sure if there's a better place to put this, but for now I can keep it here.
