### PR TITLE
Expose mock gearman job fields

### DIFF
--- a/mock/README.md
+++ b/mock/README.md
@@ -9,6 +9,11 @@
 
 ```go
 type MockJob struct {
+	Payload, Name, GearmanHandle, Id string
+	GearmanErr                       error
+	GearmanWarnings                  [][]byte
+	DataBuffer                       bytes.Buffer
+	Numerator, Denominator           int
 }
 ```
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -4,65 +4,65 @@ import "bytes"
 
 // MockJob is a fake Gearman job for tests
 type MockJob struct {
-	payload, name, handle, id string
-	err                       error
-	warnings                  [][]byte
-	data                      bytes.Buffer
-	numerator, denominator    int
+	Payload, Name, GearmanHandle, Id string
+	GearmanErr                       error
+	GearmanWarnings                  [][]byte
+	DataBuffer                       bytes.Buffer
+	Numerator, Denominator           int
 }
 
 // CreateMockJob creates an object that implements the gearman-go/worker#Job interface
 func CreateMockJob(payload string) *MockJob {
-	return &MockJob{payload: payload}
-}
-
-// Err returns the job's error
-func (m MockJob) Err() error {
-	return m.err
+	return &MockJob{Payload: payload}
 }
 
 // Data returns the Gearman payload
 func (m MockJob) Data() []byte {
-	return []byte(m.payload)
+	return []byte(m.Payload)
 }
 
 // OutData returns the Gearman outpack data
 func (m MockJob) OutData() []byte {
-	return m.data.Bytes()
+	return m.DataBuffer.Bytes()
 }
 
 // Fn returns the job's name
 func (m MockJob) Fn() string {
-	return m.name
+	return m.Name
+}
+
+// Err returns the job's error
+func (m MockJob) Err() error {
+	return m.GearmanErr
 }
 
 // Handle returns the job's handle
 func (m MockJob) Handle() string {
-	return m.handle
+	return m.GearmanHandle
 }
 
 // UniqueId returns the unique id for the job
 func (m MockJob) UniqueId() string {
-	return m.id
-}
-
-// SendWarning appends to the array of job warnings
-func (m *MockJob) SendWarning(warning []byte) {
-	m.warnings = append(m.warnings, warning)
+	return m.Id
 }
 
 // Warnings returns the array of jobs warnings
 func (m *MockJob) Warnings() [][]byte {
-	return m.warnings
+	return m.GearmanWarnings
+}
+
+// SendWarning appends to the array of job warnings
+func (m *MockJob) SendWarning(warning []byte) {
+	m.GearmanWarnings = append(m.GearmanWarnings, warning)
 }
 
 // SendData appends to the array of job data
 func (m *MockJob) SendData(data []byte) {
-	m.data.Write(data)
+	m.DataBuffer.Write(data)
 }
 
 // UpdateStatus updates the progress of job
 func (m *MockJob) UpdateStatus(numerator, denominator int) {
-	m.numerator = numerator
-	m.denominator = denominator
+	m.Numerator = numerator
+	m.Denominator = denominator
 }


### PR DESCRIPTION
I wanted to edit one of these fields directly in a test, so I decided to
make all the fields public. A couple of them have weird names because
you can't have the same name for fields and methods in Go.
